### PR TITLE
docs: update storage policy configuration and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ backup_postgres:
     DATABASE_OPTS:
 ```
 
-The default lifecycle policy is to keep the backup files for 7 days. You can change the `STORAGE_DAYS` environment variable to keep the backup files for a different number of days. You also can change the `STORAGE_PATH` environment variable to save the backup files in a different directory.
+The default lifecycle policy is disabled. You can enable it by setting the `STORAGE_DAYS` environment variable. You can change the `STORAGE_DAYS` environment variable to keep the backup files for a different number of days. You also can change the `STORAGE_PATH` environment variable to save the backup files in a different directory.
 
 ```yaml
 STORAGE_DAYS: 30

--- a/cmd/docker-backup-database/config.go
+++ b/cmd/docker-backup-database/config.go
@@ -124,7 +124,7 @@ func settingsFlags(cfg *config.Config) []cli.Flag {
 			Usage:       "Set lifecycle Days",
 			EnvVars:     []string{"PLUGIN_STORAGE_DAYS", "INPUT_STORAGE_DAYS", "STORAGE_DAYS"},
 			Destination: &cfg.Storage.Days,
-			Value:       7,
+			Value:       0,
 		},
 
 		// SCHEDULE


### PR DESCRIPTION
- Update README to indicate that the default lifecycle policy is disabled and can be enabled by setting the `STORAGE_DAYS` environment variable
- Change the default value of `STORAGE_DAYS` from 7 to 0 in the configuration file

fix https://github.com/appleboy/docker-backup-database/issues/14