### PR TITLE
fix: dumper should write output to DumpName

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ bin
 dist
 .env
 coverage.txt
+.idea/

--- a/pkg/dbdump/mysql/mysql.go
+++ b/pkg/dbdump/mysql/mysql.go
@@ -74,8 +74,15 @@ func (d Dump) Exec(ctx context.Context) error {
 	// Use a pipe to gzip the output
 	gzipCmd := exec.CommandContext(ctx, "gzip")
 	gzipCmd.Stdin, _ = cmd.StdoutPipe()
-	gzipCmd.Stdout = os.Stdout
 	gzipCmd.Stderr = os.Stderr
+
+	f, err := os.Create(d.DumpName)
+	if err != nil {
+		return fmt.Errorf("failed to create dump output file: %w", err)
+	}
+
+	defer f.Close()
+	gzipCmd.Stdout = f
 
 	trace(cmd)
 	if err := cmd.Start(); err != nil {

--- a/pkg/dbdump/postgres/postgres.go
+++ b/pkg/dbdump/postgres/postgres.go
@@ -75,8 +75,15 @@ func (d Dump) Exec(ctx context.Context) error {
 	// Use a pipe to gzip the output
 	gzipCmd := exec.CommandContext(ctx, "gzip")
 	gzipCmd.Stdin, _ = cmd.StdoutPipe()
-	gzipCmd.Stdout = os.Stdout
 	gzipCmd.Stderr = os.Stderr
+
+	f, err := os.Create(d.DumpName)
+	if err != nil {
+		return fmt.Errorf("failed to create dump output file: %w", err)
+	}
+
+	defer f.Close()
+	gzipCmd.Stdout = f
 
 	trace(cmd)
 	if err := cmd.Start(); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database dumps for MySQL and PostgreSQL are now saved directly as compressed files, avoiding stdout. This simplifies export workflows and ensures outputs are stored reliably with the expected dump filename.

* **Chores**
  * Updated ignore settings to exclude IDE project files (.idea) from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->